### PR TITLE
Cleaned up Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,20 +2,7 @@ FROM golang:1.10.3-alpine3.7 as golang-base
 
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache gcc git linux-headers make musl-dev
-
-FROM golang-base as go-ethereum-build
-
-ARG REPO_URL="https://github.com/ethereum/go-ethereum.git"
-ARG CHECKOUT_TARGET="master"
-
-RUN git clone ${REPO_URL} "/go/src/github.com/ethereum/go-ethereum"
-
-WORKDIR "/go/src/github.com/ethereum/go-ethereum"
-
-RUN git checkout ${CHECKOUT_TARGET}
-
-RUN make all
+    apk add --no-cache gcc linux-headers make musl-dev
 
 FROM golang-base as microcosm-build
 
@@ -25,12 +12,9 @@ COPY . .
 
 RUN go build
 
-FROM alpine:3.7 as main
-
-RUN apk add --no-cache ca-certificates
-
-WORKDIR /root
-
-COPY --from=go-ethereum-build "/go/src/github.com/ethereum/go-ethereum/build/bin/" /usr/local/bin/
+FROM ethereum/client-go:v1.8.12 as main
 
 COPY --from=microcosm-build "/go/src/github.com/nkashy1/microcosm/microcosm" /usr/local/bin/
+
+ENTRYPOINT []
+CMD []


### PR DESCRIPTION
No longer building ALL ethereum binaries from scratch. Instead, just
building microcosm and copying it into the ethereum/client-go container
(with tag v1.8.12). Will update the tag manually for now.

Also cleared the entrypoint from the `ethereum/client-go` container --
it is rather inflexible and annoying that it uses `geth` as the
entrypoint.