### PR TITLE
Accept geth arguments on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Create a microcosm container, bind-mounting a volume onto `/root`:
 
 ```
 MICROCOSM_DIR=$(mktemp -d)
-docker run -v $MICROCOSM_DIR:/root fuzzyfrog/microcosm <number of accounts to provision>
+docker run \
+    -e NUM_ACCOUNTS=<number of accounts to provision> \
+    -v $MICROCOSM_DIR:/root \
+    fuzzyfrog/microcosm \
+    <geth arguments>
 ```
 
 If you look in `$MICROCOSM_DIR`, you will see the `microcosm` directory. This directory
@@ -62,3 +66,17 @@ For a side-by-side view of the `microcosm`-generated accounts and passwords, you
 ```
 pr -w 100 -m -t $MICROCOSM_DIR/accounts.txt $MICROCOSM_DIR/passwords.txt
 ```
+
+## geth arguments
+
+As indicated above, you can directly pass in arguments for `geth` when you run the `microcosm`
+docker container. For example, if you want to expose the management APIs over the JSON RPC
+interface, you can run:
+```
+docker run -p 8545:8545 -e NUM_ACCOUNTS=0 -v $(cat md.txt):/root \
+    docai/microcosm:test --rpc --rpcaddr 0.0.0.0 --rpcapi eth,web3
+```
+
+Note: It is important to use `--rpcaddr 0.0.0.0` because of how docker handles loopbacks within
+containers -- using the default of `127.0.0.1` means you will be unable to connect to the RPC API
+from outside the container.

--- a/docker/fiat-lux.sh
+++ b/docker/fiat-lux.sh
@@ -23,7 +23,7 @@ if [ ! -z $DEBUG ] ; then
     $LOGGER "Running container in DEBUG mode with command: $@"
     $@
 else
-    NUM_ACCOUNTS=${1:-11}
+    NUM_ACCOUNTS=${NUM_ACCOUNTS:-11}
 
     $LOGGER "Creating $NUM_ACCOUNTS accounts"
     # Set up keystore with accounts and create genesis file
@@ -69,5 +69,5 @@ else
     $LOGGER "unlocked accounts: $REGULAR_ACCOUNTS"
 
     $LOGGER "Starting geth"
-    geth --datadir $DATA_DIR --mine --minerthreads 1 --unlock $ACCOUNTS_STRING --password $PASSWORDS_FILE --etherbase $ETHERBASE
+    geth --datadir $DATA_DIR --mine --minerthreads 1 --unlock $ACCOUNTS_STRING --password $PASSWORDS_FILE --etherbase $ETHERBASE $@
 fi


### PR DESCRIPTION
geth arguments are now accepted from the command line when container is
run.

This resolves: https://github.com/nkashy1/microcosm/issues/10

The change was made as per the discussion on that issue. So NUM_ACCOUNTS
is now taken as an environment variable rather than accepted from the
command line.