### PR TITLE
Removed microcosm genesis piping functionality

### DIFF
--- a/microcosm.go
+++ b/microcosm.go
@@ -95,15 +95,6 @@ func main() {
 		genesisFlags.Parse(subcommandArgs)
 		var rawAddresses []string
 		rawAddresses = genesisFlags.Args()
-		// If addresses have not been provided directly, check to see if they are being piped in
-		if len(rawAddresses) == 0 {
-			reader := bufio.NewReader(os.Stdin)
-			pipeInput, err := reader.ReadString('\n')
-			if err != nil && err != io.EOF {
-				log.Fatal(err)
-			}
-			rawAddresses = strings.Fields(pipeInput)
-		}
 
 		addresses := make([]common.Address, len(rawAddresses))
 		for i := 0; i < len(rawAddresses); i++ {


### PR DESCRIPTION
This was not being used in the codebase (i.e. in docker/fiat-lux.sh) and
the effect of piping can be achieved in other scripts by piping into
`xargs microcosm genesis` instead.

This resolves https://github.com/nkashy1/microcosm/issues/17, which was caused by `microcosm genesis` waiting on a newline from stdin when a user ran the script directly from the command line (as opposed to within a script).