### PR TITLE
Accept DIFFICULTY and NETWORK_ID parameters from environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ env:
     - DOCKER_IMAGE="fuzzyfrog/microcosm"
 script:
   - go test -v ./...
-  - docker build -t ${DOCKER_IMAGE}:${TRAVIS_COMMIT} -f docker/Dockerfile .
-  - docker tag ${DOCKER_IMAGE}:${TRAVIS_COMMIT} ${DOCKER_IMAGE}:${TRAVIS_BRANCH}
+  - docker build -t ${DOCKER_IMAGE}:latest -t ${DOCKER_IMAGE}:${TRAVIS_COMMIT} -t ${DOCKER_IMAGE}:${TRAVIS_BRANCH} -f docker/Dockerfile .
 deploy:
   provider: script
-  script: sh scripts/docker-push.sh ${DOCKER_IMAGE}:${TRAVIS_BRANCH}
+  script: sh scripts/docker-push.sh ${DOCKER_IMAGE}
   on:
     tags: true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The only requirement is [Docker](https://www.docker.com/get-docker).
 Pull the latest `microcosm` image from DockerHub:
 
 ```
-docker pull fuzzyfrog/microcosm:v0.1.0
+docker pull fuzzyfrog/microcosm
 ```
 
 Create a microcosm container, bind-mounting a volume onto `/root`:
@@ -35,7 +35,7 @@ MICROCOSM_DIR=$(mktemp -d)
 docker run \
     -e NUM_ACCOUNTS=<number of accounts to provision> \
     -v $MICROCOSM_DIR:/root \
-    fuzzyfrog/microcosm:v0.1.0 \
+    fuzzyfrog/microcosm \
     <geth arguments>
 ```
 
@@ -74,8 +74,8 @@ As indicated above, you can directly pass in arguments for `geth` when you run t
 docker container. For example, if you want to expose the management APIs over the JSON RPC
 interface, you can run:
 ```
-docker run -p 8545:8545 -e NUM_ACCOUNTS=0 -v $MICROCOSM_DIR:/root \
-    fuzzyfrog/microcosm:test --rpc --rpcaddr 0.0.0.0 --rpcapi eth,web3
+docker run -p 8545:8545 -e NUM_ACCOUNTS=1 -v $MICROCOSM_DIR:/root \
+    fuzzyfrog/microcosm --rpc --rpcaddr 0.0.0.0 --rpcapi eth,web3
 ```
 
 Note: It is important to use `--rpcaddr 0.0.0.0` because of how docker handles loopbacks within
@@ -108,5 +108,6 @@ You can modify the size of your microcosm volume in your custom `values.yaml` fi
 
 ### Caveats
 
-1. If you do not set `--networkid` in your geth args, state will not persist between pod restarts.
-See the [`helm/values.yaml`](./helm/values.yaml) for an example.
+1. If you do not set `--networkid` in your values file, state will not persist between pod restarts.
+This is done via the `microcosm.networkId` parameter. See the
+[`helm/values.yaml`](./helm/values.yaml) for an example.

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -26,6 +26,10 @@ spec:
           env:
             - name: NUM_ACCOUNTS
               value: "{{ .Values.microcosm.numAccounts }}"
+            - name: NETWORK_ID
+              value: "{{ .Values.microcosm.networkId }}"
+            - name: DIFFICULTY
+              value: "{{ .Values.microcosm.difficulty }}"
           args:
           {{- range .Values.microcosm.gethArgs }}
             - {{ . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,11 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 microcosm:
-  gethArgs: ["--networkid", "\"7001337\"", "--rpc", "--rpcaddr", "0.0.0.0", "--rpcapi", "eth,web3,net,admin,personal", "--ws", "--wsaddr", "0.0.0.0", "--wsapi", "eth,web3,personal"]
+  gethArgs: ["--rpc", "--rpcaddr", "0.0.0.0", "--rpcapi", "eth,web3,net,admin,personal", "--ws", "--wsaddr", "0.0.0.0", "--wsapi", "eth,web3,personal"]
   numAccounts: 1
+  networkId: 7001337
+  difficulty: 1
   image:
     repository: fuzzyfrog/microcosm
-    tag: v0.1.0
+    tag: latest
     pullPolicy: IfNotPresent
   storageCapacity: 100Gi
   storageClassName: standard


### PR DESCRIPTION
This ensures that the private network a user provisions is configurable and that the right network is used by geth on startup.